### PR TITLE
fix: fixing invalid origin HTTP port dPanel agent

### DIFF
--- a/cmd/cli/machineCmd.go
+++ b/cmd/cli/machineCmd.go
@@ -186,7 +186,7 @@ func (m *MachineCmd) create() *cobra.Command {
 				}
 
 				// set domain for this machine
-				m.httpPort = tunnelHTTPPort
+				m.httpPort = originHTTPPort
 				m.domain = router.Data.Domain
 			}
 


### PR DESCRIPTION
# Description

Fixing invalid config dPanel Agent port in ogirin resource behind tunnel