### PR TITLE
feat: Marijan tunnel upgrader

### DIFF
--- a/cluster-example/.gitignore
+++ b/cluster-example/.gitignore
@@ -1,0 +1,1 @@
+docker-compose-dev.yaml

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
-	golang.org/x/mod v0.18.0 // indirect
+	golang.org/x/mod v0.18.0
 	golang.org/x/sys v0.32.0 // indirect
 	gorm.io/datatypes v1.2.0 // indirect
 	gorm.io/driver/mysql v1.4.7 // indirect

--- a/internal/tunnel/helper.go
+++ b/internal/tunnel/helper.go
@@ -1,0 +1,37 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type latestResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+func getLatestReleaseVersion() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/devetek/tuman/releases/latest")
+	if err != nil {
+		return "", fmt.Errorf("failed to make HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var release latestResponse
+	err = json.Unmarshal(body, &release)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal JSON response: %w", err)
+	}
+
+	return release.TagName, nil
+}


### PR DESCRIPTION
# Description

New command to help upgrade Marijan "Tunnel Manager"

```sh
Simplify the process of managing resource such as user, machine, and application in dPanel (Devetek Panel).

Full documentation is available at: https://cloud.terpusat.com/docs/

Usage:
  dnocs [command]

Available Commands:
  auth        Manage dPanel session
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  info        Prints the system info
  machine     Manage dPanel machine
  tunnel      Manage dPanel tunnel
  version     Prints the version

Flags:
  -h, --help      help for dnocs
  -v, --version   version for dnocs

Use "dnocs [command] --help" for more information about a command.
```

## Type of change

- [x] New tunnel command `upgrade`, to help upgrade marijan binary